### PR TITLE
Adding standard, xo support; improving linter detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ At the moment the following linters are detected:
 - [coffeelint](http://coffeelint.org)
 - [tslint](https://palantir.github.io/tslint/)
 - [prettier](https://prettier.io/)
+- [standard](https://standardjs.com/)
 
 Feel free to a PR to include other linters as part of the detection!
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ At the moment the following linters are detected:
 - [tslint](https://palantir.github.io/tslint/)
 - [prettier](https://prettier.io/)
 - [standard](https://standardjs.com/)
+- [xo](https://github.com/xojs/xo/)
 
 Feel free to a PR to include other linters as part of the detection!
 

--- a/lib/coffeelint.js
+++ b/lib/coffeelint.js
@@ -10,7 +10,7 @@ function detectCoffeeLint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, 'coffeelintConfig'),
+        tryPackageJson(dir, ['coffeelintConfig']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/coffeelint.js
+++ b/lib/coffeelint.js
@@ -10,7 +10,7 @@ function detectCoffeeLint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, ['coffeelintConfig']),
+        tryPackageJson(dir, ['coffeelintConfig', 'devDependencies.coffeelint']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/csslint.js
+++ b/lib/csslint.js
@@ -2,12 +2,17 @@
 
 const path = require('path');
 const tryFiles = require('./util/tryFiles');
+const tryPackageJson = require('./util/tryPackageJson');
 
 function detectCssLint(dir) {
     const paths = ['.csslintrc']
     .map((entry) => path.join(dir, entry));
 
-    return tryFiles(paths);
+    return Promise.all([
+        tryFiles(paths),
+        tryPackageJson(dir, ['devDependencies.csslint']),
+    ])
+    .then((booleans) => booleans.some((bool) => bool));
 }
 
 module.exports = detectCssLint;

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -10,7 +10,7 @@ function detectEslint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, ['eslint', 'eslintConfig', 'eslintIgnore']),
+        tryPackageJson(dir, ['devDependencies.eslint', 'eslintConfig', 'eslintIgnore']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -10,7 +10,7 @@ function detectEslint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, 'eslintConfig'),
+        tryPackageJson(dir, ['eslint', 'eslintConfig', 'eslintIgnore']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/htmlhint.js
+++ b/lib/htmlhint.js
@@ -2,12 +2,17 @@
 
 const path = require('path');
 const tryFiles = require('./util/tryFiles');
+const tryPackageJson = require('./util/tryPackageJson');
 
 function detectHtmlHint(dir) {
     const paths = ['.htmlhintrc']
     .map((entry) => path.join(dir, entry));
 
-    return tryFiles(paths);
+    return Promise.all([
+        tryFiles(paths),
+        tryPackageJson(dir, ['devDependencies.htmlhint']),
+    ])
+    .then((booleans) => booleans.some((bool) => bool));
 }
 
 module.exports = detectHtmlHint;

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -7,6 +7,8 @@ function detectHtmlHint(dir) {
     const paths = ['.htmllintrc']
     .map((entry) => path.join(dir, entry));
 
+    // htmllint doesn't run without a config file, so no need to
+    // check dependencies
     return tryFiles(paths);
 }
 

--- a/lib/jscs.js
+++ b/lib/jscs.js
@@ -10,7 +10,7 @@ function detectJscs(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, 'jscsConfig'),
+        tryPackageJson(dir, ['jscsConfig']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/jshint.js
+++ b/lib/jshint.js
@@ -10,7 +10,7 @@ function detectJsHint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, ['jshintConfig']),
+        tryPackageJson(dir, ['devDependencies.jshint', 'jshintConfig']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/jshint.js
+++ b/lib/jshint.js
@@ -10,7 +10,7 @@ function detectJsHint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, 'jshintConfig'),
+        tryPackageJson(dir, ['jshintConfig']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/prettier.js
+++ b/lib/prettier.js
@@ -10,7 +10,7 @@ function detectPrettierLint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, ['prettier']),
+        tryPackageJson(dir, ['devDependencies.prettier', 'prettier']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/prettier.js
+++ b/lib/prettier.js
@@ -10,7 +10,7 @@ function detectPrettierLint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, 'prettier'),
+        tryPackageJson(dir, ['prettier']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/standard.js
+++ b/lib/standard.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const tryPackageJson = require('./util/tryPackageJson');
+
+function detectStandardLint(dir) {
+    return tryPackageJson(dir, ['standard']);
+}
+
+module.exports = detectStandardLint;

--- a/lib/standard.js
+++ b/lib/standard.js
@@ -3,7 +3,7 @@
 const tryPackageJson = require('./util/tryPackageJson');
 
 function detectStandardLint(dir) {
-    return tryPackageJson(dir, ['standard']);
+    return tryPackageJson(dir, ['devDependencies.standard', 'standard']);
 }
 
 module.exports = detectStandardLint;

--- a/lib/stylelint.js
+++ b/lib/stylelint.js
@@ -10,7 +10,7 @@ function detectStyleLint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, ['stylelint']),
+        tryPackageJson(dir, ['devDependencies.stylelint', 'stylelint']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/stylelint.js
+++ b/lib/stylelint.js
@@ -10,7 +10,7 @@ function detectStyleLint(dir) {
 
     return Promise.all([
         tryFiles(paths),
-        tryPackageJson(dir, 'stylelint'),
+        tryPackageJson(dir, ['stylelint']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/tslint.js
+++ b/lib/tslint.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const tryFiles = require('./util/tryFiles');
+const tryPackageJson = require('./util/tryPackageJson');
 
 function detectTsLint(dir) {
     const paths = ['tslint.json']
@@ -9,6 +10,7 @@ function detectTsLint(dir) {
 
     return Promise.all([
         tryFiles(paths),
+        tryPackageJson(dir, ['devDependencies.tslint']),
     ])
     .then((booleans) => booleans.some((bool) => bool));
 }

--- a/lib/util/tryPackageJson.js
+++ b/lib/util/tryPackageJson.js
@@ -2,36 +2,12 @@
 
 const path = require('path');
 const loadJsonFile = require('load-json-file');
-
-function objectPath(obj, propPath) {
-    const props = propPath.split('.');
-    const propsLength = props.length;
-    let target = obj;
-    let result;
-
-    for (let i = 0; i < propsLength; i += 1) {
-        const prop = props[i];
-
-        if (target[prop]) {
-            const value = target[prop];
-
-            if (i === (propsLength - 1)) {
-                result = value;
-            } else {
-                target = value;
-            }
-        } else {
-            break;
-        }
-    }
-
-    return result;
-}
+const get = require('lodash.get');
 
 function tryPackageJson(dir, props) {
     return loadJsonFile(path.join(dir, 'package.json'))
     .then((json) => {
-        return props.some((prop) => objectPath(json, prop));
+        return props.some((prop) => get(json, prop));
     }, (err) => {
         if (err.code === 'ENOENT') {
             return false;

--- a/lib/util/tryPackageJson.js
+++ b/lib/util/tryPackageJson.js
@@ -3,21 +3,35 @@
 const path = require('path');
 const loadJsonFile = require('load-json-file');
 
+function objectPath(obj, propPath) {
+    const props = propPath.split('.');
+    const propsLength = props.length;
+    let target = obj;
+    let result;
+
+    for (let i = 0; i < propsLength; i += 1) {
+        const prop = props[i];
+
+        if (target[prop]) {
+            const value = target[prop];
+
+            if (i === (propsLength - 1)) {
+                result = value;
+            } else {
+                target = value;
+            }
+        } else {
+            break;
+        }
+    }
+
+    return result;
+}
+
 function tryPackageJson(dir, props) {
     return loadJsonFile(path.join(dir, 'package.json'))
     .then((json) => {
-        return props.some((prop) => {
-            const hasConfig = !!json[prop];
-            let hasDep = false;
-
-            if (json.dependencies) {
-                hasDep = (typeof json.dependencies[prop] === 'string');
-            } else if (json.devDependencies) {
-                hasDep = (typeof json.devDependencies[prop] === 'string');
-            }
-
-            return hasConfig || hasDep;
-        });
+        return props.some((prop) => objectPath(json, prop));
     }, (err) => {
         if (err.code === 'ENOENT') {
             return false;

--- a/lib/util/tryPackageJson.js
+++ b/lib/util/tryPackageJson.js
@@ -6,10 +6,10 @@ const loadJsonFile = require('load-json-file');
 function tryPackageJson(dir, props) {
     return loadJsonFile(path.join(dir, 'package.json'))
     .then((json) => {
-        return props.some(prop => {
+        return props.some((prop) => {
             const { dependencies, devDependencies } = json;
             const hasConfig = !!json[prop];
-            let hasDep = false
+            let hasDep = false;
 
             if (dependencies) {
                 hasDep = (typeof dependencies[prop] === 'string');
@@ -18,7 +18,7 @@ function tryPackageJson(dir, props) {
             }
 
             return hasConfig || hasDep;
-        })
+        });
     }, (err) => {
         if (err.code === 'ENOENT') {
             return false;

--- a/lib/util/tryPackageJson.js
+++ b/lib/util/tryPackageJson.js
@@ -7,14 +7,13 @@ function tryPackageJson(dir, props) {
     return loadJsonFile(path.join(dir, 'package.json'))
     .then((json) => {
         return props.some((prop) => {
-            const { dependencies, devDependencies } = json;
             const hasConfig = !!json[prop];
             let hasDep = false;
 
-            if (dependencies) {
-                hasDep = (typeof dependencies[prop] === 'string');
-            } else if (devDependencies) {
-                hasDep = (typeof devDependencies[prop] === 'string');
+            if (json.dependencies) {
+                hasDep = (typeof json.dependencies[prop] === 'string');
+            } else if (json.devDependencies) {
+                hasDep = (typeof json.devDependencies[prop] === 'string');
             }
 
             return hasConfig || hasDep;

--- a/lib/util/tryPackageJson.js
+++ b/lib/util/tryPackageJson.js
@@ -3,9 +3,23 @@
 const path = require('path');
 const loadJsonFile = require('load-json-file');
 
-function tryPackageJson(dir, prop) {
+function tryPackageJson(dir, props) {
     return loadJsonFile(path.join(dir, 'package.json'))
-    .then((json) => !!json[prop], (err) => {
+    .then((json) => {
+        return props.some(prop => {
+            const { dependencies, devDependencies } = json;
+            const hasConfig = !!json[prop];
+            let hasDep = false
+
+            if (dependencies) {
+                hasDep = (typeof dependencies[prop] === 'string');
+            } else if (devDependencies) {
+                hasDep = (typeof devDependencies[prop] === 'string');
+            }
+
+            return hasConfig || hasDep;
+        })
+    }, (err) => {
         if (err.code === 'ENOENT') {
             return false;
         }

--- a/lib/xo.js
+++ b/lib/xo.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const tryPackageJson = require('./util/tryPackageJson');
+
+function detectXOLint(dir) {
+    return tryPackageJson(dir, ['devDependencies.xo', 'xo']);
+}
+
+module.exports = detectXOLint;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "stylelint",
     "csslint",
     "htmlhint",
-    "htmllint"
+    "htmllint",
+    "xo"
   ],
   "author": "IndigoUnited <hello@indigounited.com> (http://indigounited.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "load-json-file": "^3.0.0",
+    "lodash.get": "^4.4.2",
     "require-directory": "^2.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jshint",
     "jscs",
     "jslint",
+    "standard",
     "stylelint",
     "csslint",
     "htmlhint",

--- a/test/test.js
+++ b/test/test.js
@@ -329,6 +329,25 @@ it('should detect standard', () => {
     .then(assert);
 });
 
+it('should detect xo', () => {
+    function assert(linters) {
+        expect(linters).to.eql(['xo']);
+    }
+
+    cleanTmpFolder();
+    fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ xo: {} }));
+
+    return detectRepoLinters(tmpFolder)
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { xo: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
+    .then(assert);
+});
+
 it('should detect several linters in a complex repository', () => {
     cleanTmpFolder();
     fs.writeFileSync(`${tmpFolder}/.editorconfig`, '');

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,7 @@ it('should detect eslint', () => {
     .then(assert)
     .then(() => {
         cleanTmpFolder();
-        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ dependencies: { eslint: '^x.x.x' } }));
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { eslint: '^x.x.x' } }));
 
         return detectRepoLinters(tmpFolder);
     })
@@ -130,6 +130,13 @@ it('should detect jshint', () => {
 
         return detectRepoLinters(tmpFolder);
     })
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { jshint: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
     .then(assert);
 });
 
@@ -170,6 +177,13 @@ it('should detect stylelint', () => {
 
         return detectRepoLinters(tmpFolder);
     })
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { stylelint: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
     .then(assert);
 });
 
@@ -182,6 +196,13 @@ it('should detect csslint', () => {
     fs.writeFileSync(`${tmpFolder}/.csslintrc`, '');
 
     return detectRepoLinters(tmpFolder)
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { csslint: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
     .then(assert);
 });
 
@@ -194,6 +215,13 @@ it('should detect htmlhint', () => {
     fs.writeFileSync(`${tmpFolder}/.htmlhintrc`, '');
 
     return detectRepoLinters(tmpFolder)
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { htmlhint: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
     .then(assert);
 });
 
@@ -224,6 +252,13 @@ it('should detect coffeelint', () => {
         fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ coffeelintConfig: {} }));
         return detectRepoLinters(tmpFolder);
     })
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { coffeelint: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
     .then(assert);
 });
 
@@ -236,7 +271,14 @@ it('should detect tslint', () => {
     fs.writeFileSync(`${tmpFolder}/tslint.json`, '');
 
     return detectRepoLinters(tmpFolder)
-        .then(assert);
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { tslint: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
+    .then(assert);
 });
 
 it('should detect prettier', () => {
@@ -256,6 +298,13 @@ it('should detect prettier', () => {
         .then(() => {
             cleanTmpFolder();
             fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ prettier: {} }));
+            return detectRepoLinters(tmpFolder);
+        })
+        .then(assert)
+        .then(() => {
+            cleanTmpFolder();
+            fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { prettier: '^x.x.x' } }));
+
             return detectRepoLinters(tmpFolder);
         })
         .then(assert);

--- a/test/test.js
+++ b/test/test.js
@@ -247,6 +247,25 @@ it('should detect prettier', () => {
         .then(assert);
 });
 
+it('should detect standard', () => {
+    function assert(linters) {
+        expect(linters).to.eql(['standard']);
+    }
+
+    cleanTmpFolder();
+    fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { standard: '^x.x.x' } }));
+
+    return detectRepoLinters(tmpFolder)
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ standard: {} }));
+
+        return detectRepoLinters(tmpFolder);
+    })
+    .then(assert);
+});
+
 it('should detect several linters in a complex repository', () => {
     cleanTmpFolder();
     fs.writeFileSync(`${tmpFolder}/.editorconfig`, '');

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,20 @@ it('should detect eslint', () => {
 
         return detectRepoLinters(tmpFolder);
     })
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ eslintIgnore: {} }));
+
+        return detectRepoLinters(tmpFolder);
+    })
+    .then(assert)
+    .then(() => {
+        cleanTmpFolder();
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { eslint: '^x.x.x' } }));
+
+        return detectRepoLinters(tmpFolder);
+    })
     .then(assert);
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,7 @@ it('should detect eslint', () => {
     .then(assert)
     .then(() => {
         cleanTmpFolder();
-        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ devDependencies: { eslint: '^x.x.x' } }));
+        fs.writeFileSync(`${tmpFolder}/package.json`, JSON.stringify({ dependencies: { eslint: '^x.x.x' } }));
 
         return detectRepoLinters(tmpFolder);
     })


### PR DESCRIPTION
Fixes #13. Adding `standard` support. ~for #13~

Also, added support for detecting dependencies/devDependencies since a lot of users of `standard` won't have any configuration (kinda the whole point of standard, lol), so detecting based on whether they have any config in their `package.json` isn't super reliable. With this addition, I also added a couple more checks in the `eslint` detector